### PR TITLE
Fix ParseProblemException

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>3.23.0</version>
+            <version>3.26.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Changed the JavaParser dependency to the most recent version 3.26.3 to fix the ParseProblemException
This JavaParser version can parse the Record keyword