### PR TITLE
Implement ast analyzer config

### DIFF
--- a/src/main/java/com/sdg/ast/ASTAnalyzerConfig.java
+++ b/src/main/java/com/sdg/ast/ASTAnalyzerConfig.java
@@ -1,0 +1,115 @@
+package com.sdg.ast;
+
+/**
+ * Configuration class for the {@link ASTAnalyzer}.
+ *
+ * Configuration to turn on/off various features of the analyzer can be beneficial during development.
+ *
+ * @author Joakim Colloz
+ */
+public class ASTAnalyzerConfig {
+    private boolean analyzeMethods = true;
+    private boolean analyzeMethodCalls = true;
+    private boolean analyzeClassFields = true;
+    private boolean analyzeInheritance = true;
+    private boolean analyzeImports = true;
+    private boolean analyzeInterfaceImplementations = true;
+    private boolean analyzeControlFlow = true;
+
+    public ASTAnalyzerConfig analyzeMethods(boolean analyzeMethods) {
+        this.analyzeMethods = analyzeMethods;
+        return this;
+    }
+
+    public ASTAnalyzerConfig analyzeMethodCalls(boolean analyzeMethodCalls) {
+        this.analyzeMethodCalls = analyzeMethodCalls;
+        return this;
+    }
+
+    public ASTAnalyzerConfig analyzeClassFields(boolean analyzeClassFields) {
+        this.analyzeClassFields = analyzeClassFields;
+        return this;
+    }
+
+    public ASTAnalyzerConfig analyzeInheritance(boolean analyzeInheritance) {
+        this.analyzeInheritance = analyzeInheritance;
+        return this;
+    }
+
+    public ASTAnalyzerConfig analyzeImports(boolean analyzeImports) {
+        this.analyzeImports = analyzeImports;
+        return this;
+    }
+
+    public ASTAnalyzerConfig analyzeInterfaceImplementations(boolean analyzeInterfaceImplementations) {
+        this.analyzeInterfaceImplementations = analyzeInterfaceImplementations;
+        return this;
+    }
+
+    public ASTAnalyzerConfig analyzeControlFlow(boolean analyzeControlFlow) {
+        this.analyzeControlFlow = analyzeControlFlow;
+        return this;
+    }
+
+    // Setters
+
+    public void setAnalyzeMethods(boolean analyzeMethods) {
+        this.analyzeMethods = analyzeMethods;
+    }
+
+    public void setAnalyzeMethodCalls(boolean analyzeMethodCalls) {
+        this.analyzeMethodCalls = analyzeMethodCalls;
+    }
+
+    public void setAnalyzeClassFields(boolean analyzeClassFields) {
+        this.analyzeClassFields = analyzeClassFields;
+    }
+
+    public void setAnalyzeInheritance(boolean analyzeInheritance) {
+        this.analyzeInheritance = analyzeInheritance;
+    }
+
+    public void setAnalyzeImports(boolean analyzeImports) {
+        this.analyzeImports = analyzeImports;
+    }
+
+    public void setAnalyzeInterfaceImplementations(boolean analyzeInterfaceImplementations) {
+        this.analyzeInterfaceImplementations = analyzeInterfaceImplementations;
+    }
+
+    public void setAnalyzeControlFlow(boolean analyzeControlFlow) {
+        this.analyzeControlFlow = analyzeControlFlow;
+    }
+
+    // Getters
+
+    public boolean isAnalyzeMethods() {
+        return analyzeMethods;
+    }
+
+    public boolean isAnalyzeMethodCalls() {
+        return analyzeMethodCalls;
+    }
+
+    public boolean isAnalyzeClassFields() {
+        return analyzeClassFields;
+    }
+
+    public boolean isAnalyzeInheritance() {
+        return analyzeInheritance;
+    }
+
+    public boolean isAnalyzeImports() {
+        return analyzeImports;
+    }
+
+    public boolean isAnalyzeInterfaceImplementations() {
+        return analyzeInterfaceImplementations;
+    }
+
+    public boolean isAnalyzeControlFlow() {
+        return analyzeControlFlow;
+    }
+
+
+}

--- a/src/main/java/com/sdg/controller/InputController.java
+++ b/src/main/java/com/sdg/controller/InputController.java
@@ -1,5 +1,6 @@
 package com.sdg.controller;
 
+import com.sdg.ast.ASTAnalyzerConfig;
 import com.sdg.graph.KnowledgeGraphService;
 import com.sdg.model.InputHandler.ProcessingResult;
 import com.sdg.view.InputView;
@@ -135,7 +136,15 @@ public class InputController {
     public static void start() {
         SwingUtilities.invokeLater(() -> {
             InputView view = new InputView();
-            KnowledgeGraphService graphService = new KnowledgeGraphService();  // Initialize KnowledgeGraphService
+
+            // Configure ASTAnalyzer to turn off analysis of methods, method calls and class fields
+            ASTAnalyzerConfig config = new ASTAnalyzerConfig()
+                    .analyzeClassFields(false)
+                    .analyzeControlFlow(false)
+                    .analyzeMethods(false)
+                    .analyzeMethodCalls(false);
+
+            KnowledgeGraphService graphService = new KnowledgeGraphService(config);  // Initialize KnowledgeGraphService
             InputController controller = new InputController(view, graphService);
 
             // Ensure resources are disposed of when the application exits

--- a/src/main/java/com/sdg/graph/KnowledgeGraphService.java
+++ b/src/main/java/com/sdg/graph/KnowledgeGraphService.java
@@ -1,6 +1,7 @@
 package com.sdg.graph;
 
 import com.github.javaparser.ast.CompilationUnit;
+import com.sdg.ast.ASTAnalyzerConfig;
 import com.sdg.logging.LoggerUtil;
 import com.sdg.model.InputHandler;
 import com.sdg.model.InputHandler.ProcessingResult;
@@ -35,6 +36,20 @@ public class KnowledgeGraphService implements AutoCloseable {
         this.parser = new JavaFileParser();
         this.dbOps = new GraphDatabaseOperations();
         this.analyzer = new ASTAnalyzer(dbOps);
+        this.visualizer = new GraphVisualizer();
+        this.inputHandler = new InputHandler();  // Initialize InputHandler
+    }
+
+    /**
+     * Constructor accepting a {@link com.sdg.ast.ASTAnalyzerConfig}.
+     *
+     * @param config the configuration for the ASTAnalyzer
+     */
+    public KnowledgeGraphService(final ASTAnalyzerConfig config) {
+        LoggerUtil.info(getClass(), "Initializing KnowledgeGraphService");
+        this.parser = new JavaFileParser();
+        this.dbOps = new GraphDatabaseOperations();
+        this.analyzer = new ASTAnalyzer(dbOps, config);
         this.visualizer = new GraphVisualizer();
         this.inputHandler = new InputHandler();  // Initialize InputHandler
     }


### PR DESCRIPTION
Add a class to configure what to include for analysis in the ASTAnalyzer. This can be helpful during development to determine what is most necessary to include while keeping the resulting knowledge graph as small as possible.