### PR TITLE
Reset database between imports

### DIFF
--- a/src/main/java/com/sdg/Main.java
+++ b/src/main/java/com/sdg/Main.java
@@ -1,13 +1,9 @@
 package com.sdg;
 
 import com.sdg.controller.InputController;
-import com.sdg.graph.GraphDatabaseOperations;
 
 public class Main {
     public static void main(String[] args) throws Exception {
-        GraphDatabaseOperations dbOps = new GraphDatabaseOperations();
-        dbOps.deleteAllData();
-        dbOps.close();
         InputController.start();
     }
 }

--- a/src/main/java/com/sdg/controller/InputController.java
+++ b/src/main/java/com/sdg/controller/InputController.java
@@ -77,8 +77,9 @@ public class InputController {
         view.getDescButton().setEnabled(true);
 
         // Subscribe to the RxJava observable processing files asynchronously
+        final boolean resetDatabase = true;
         disposables.add(
-                graphService.processKnowledgeGraph(inputPath)
+                graphService.processKnowledgeGraph(inputPath, resetDatabase)
                         .subscribeOn(Schedulers.io())
                         .observeOn(swingScheduler)
                         .doOnSubscribe(disposable -> view.showLoadingIndicator("Processing " +

--- a/src/main/java/com/sdg/graph/KnowledgeGraphService.java
+++ b/src/main/java/com/sdg/graph/KnowledgeGraphService.java
@@ -71,7 +71,11 @@ public class KnowledgeGraphService implements AutoCloseable {
      * @param inputPath Path to the source files.
      * @return Observable stream of processing results.
      */
-    public Observable<ProcessingResult> processKnowledgeGraph(String inputPath) {
+    public Observable<ProcessingResult> processKnowledgeGraph(String inputPath, boolean resetDatabase) {
+        if (resetDatabase) {
+            dbOps.deleteAllData();
+        }
+
         LoggerUtil.info(getClass(), "Processing knowledge graph for path: {}", inputPath);
 
         long start = System.currentTimeMillis();

--- a/src/test/java/com/sdg/graph/GraphDataToJsonConverterTest.java
+++ b/src/test/java/com/sdg/graph/GraphDataToJsonConverterTest.java
@@ -73,11 +73,12 @@ class GraphDataToJsonConverterTest {
         String childPath = Paths.get(childUrl.toURI()).toString();
 
         // Process each file and wait for completion
-        knowledgeGraphService.processKnowledgeGraph(interfacePath)
+        final boolean resetDatabase = false;
+        knowledgeGraphService.processKnowledgeGraph(interfacePath, resetDatabase)
             .blockingSubscribe();
-        knowledgeGraphService.processKnowledgeGraph(parentPath)
+        knowledgeGraphService.processKnowledgeGraph(parentPath, resetDatabase)
             .blockingSubscribe();
-        knowledgeGraphService.processKnowledgeGraph(childPath)
+        knowledgeGraphService.processKnowledgeGraph(childPath, resetDatabase)
             .blockingSubscribe();
 
         // Give Neo4j a moment to process all transactions


### PR DESCRIPTION
Delete all data within the database when clicking the 'Create Knowledge Graph' button. Previously, the database was only deleted once from the main method when the application was started.